### PR TITLE
Summary is required in gemspec

### DIFF
--- a/pearson_sdk.gemspec
+++ b/pearson_sdk.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Pearson::VERSION
   spec.authors       = ["Pearson plc., Andrew Cantino (http://andrewcantino.com)"]
   spec.email         = ["toby.sims@pearson.com"]
-  spec.description   = %q{A Ruby Client Library for accessing the Pearson API}
+  spec.summary       = %q{A Ruby Client Library for accessing the Pearson API}
   spec.homepage      = "https://developer.pearson.com/apis/"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Summary is required and description is optional in the gemspec.
Causing errors in Bundler version 1.12.5, ruby 2.3.0 using rbenv

```
You have one or more invalid gemspecs that need to be fixed.
The gemspec at
/home/.../.rbenv/versions/2.3.0/gemsets/.../gems/Pearson-Api-Sdk-Ruby-964aae7580eb/pearson_sdk.gemspec
is not valid. Please fix this gemspec.
The validation error was 'missing value for attribute summary'
```

http://guides.rubygems.org/specification-reference/
